### PR TITLE
Добавлен скрипт Feature/collect files для рекурсивного сбора файлов

### DIFF
--- a/collect_files.sh
+++ b/collect_files.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+INPUT_DIR="$1"
+OUTPUT_DIR="$2"
+
+if [[ "$#" -lt 2 ]]; then
+  echo "Usage: $0 <input_dir> <output_dir> [--max_depth N]"
+  exit 1
+fi
+
+MAX_DEPTH=""
+if [[ "$3" == "--max_depth" && -n "$4" ]]; then
+  MAX_DEPTH="$4"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+copy_files() {
+  local dir="$1"
+  local current_depth="$2"
+
+  for item in "$dir"/*; do
+    if [[ -f "$item" ]]; then
+      filename=$(basename "$item")
+      base="${filename%.*}"
+      ext="${filename##*.}"
+      dest="$OUTPUT_DIR/$filename"
+      counter=1
+      while [[ -e "$dest" ]]; do
+        dest="$OUTPUT_DIR/${base}${counter:+_$counter}.${ext}"
+        ((counter++))
+      done
+      cp "$item" "$dest"
+    elif [[ -d "$item" ]]; then
+      if [[ -z "$MAX_DEPTH" || "$current_depth" -lt "$MAX_DEPTH" ]]; then
+        copy_files "$item" $((current_depth + 1))
+      fi
+    fi
+  done
+}
+
+copy_files "$INPUT_DIR" 1

--- a/collect_files.sh
+++ b/collect_files.sh
@@ -1,42 +1,41 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-INPUT_DIR="$1"
-OUTPUT_DIR="$2"
+max_depth=""
+if [[ "${1-:-}" == "--max_depth" ]]; then
+  max_depth="$2"
+  shift 2
+fi
 
-if [[ "$#" -lt 2 ]]; then
-  echo "Usage: $0 <input_dir> <output_dir> [--max_depth N]"
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 [--max_depth N] <input_dir> <output_dir>"
   exit 1
 fi
 
-MAX_DEPTH=""
-if [[ "$3" == "--max_depth" && -n "$4" ]]; then
-  MAX_DEPTH="$4"
+input_dir="$1"
+output_dir="$2"
+
+if [[ ! -d "$input_dir" ]]; then
+  echo "Error: input directory '$input_dir' not found."
+  exit 1
 fi
 
-mkdir -p "$OUTPUT_DIR"
+mkdir -p "$output_dir"
 
-copy_files() {
-  local dir="$1"
-  local current_depth="$2"
+find_args=()
+if [[ -n "$max_depth" ]]; then
+  find_args=( -maxdepth "$max_depth" )
+fi
 
-  for item in "$dir"/*; do
-    if [[ -f "$item" ]]; then
-      filename=$(basename "$item")
-      base="${filename%.*}"
-      ext="${filename##*.}"
-      dest="$OUTPUT_DIR/$filename"
-      counter=1
-      while [[ -e "$dest" ]]; do
-        dest="$OUTPUT_DIR/${base}${counter:+_$counter}.${ext}"
-        ((counter++))
-      done
-      cp "$item" "$dest"
-    elif [[ -d "$item" ]]; then
-      if [[ -z "$MAX_DEPTH" || "$current_depth" -lt "$MAX_DEPTH" ]]; then
-        copy_files "$item" $((current_depth + 1))
-      fi
-    fi
+find "$input_dir" "${find_args[@]}" -type f -print0 | while IFS= read -r -d '' file; do
+  name=$(basename "$file")
+  base="${name%.*}"
+  ext="${name##*.}"
+  dest="$output_dir/$name"
+  i=1
+  while [[ -e "$dest" ]]; do
+    dest="$output_dir/${base}_$i.${ext}"
+    ((i++))
   done
-}
-
-copy_files "$INPUT_DIR" 1
+  cp "$file" "$dest"
+done


### PR DESCRIPTION
Реализован Bash-скрипт collect_files.sh для обхода входной директории и копирования всех файлов в выходную папку без сохранения структуры:
Рекурсивно ищет все файлы любой глубины. Принимает два параметра: INPUT_DIR и OUTPUT_DIR. Поддерживает опцию max_depth N для ограничения глубины обхода. Если в выходной папке уже есть файл с таким именем, добавляет суффикс 1, 2 и т.д. Завершает работу с кодом ошибки, если INPUT_DIR не существует или переданы неверные аргументы. Использовал обсуждения на форумах: https://stackoverflow.com/questions/20211911/find-all-files-and-copy-them-to-a-folder-flatten-recursively
И https://stackoverflow.com/questions/20799905/flatten-directory-structure-and-preserve-duplicate-files/20799994
Также, следующую статью: https://www.baeldung.com/linux/flattening-nested-directory